### PR TITLE
Add get roles by ID endpoint, update mongo script to include ID

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,15 +10,15 @@ import (
 
 //API provides a struct to wrap the api around
 type API struct {
-	Router  *mux.Router
-	mongoDB PermissionsStore
+	Router           *mux.Router
+	permissionsStore PermissionsStore
 }
 
 //Setup function sets up the api and returns an api
-func Setup(ctx context.Context, r *mux.Router, mongoDB PermissionsStore) *API {
+func Setup(ctx context.Context, r *mux.Router, permissionsStore PermissionsStore) *API {
 	api := &API{
-		Router:  r,
-		mongoDB: mongoDB,
+		Router:           r,
+		permissionsStore: permissionsStore,
 	}
 
 	log.Event(ctx, "remove hello endpoint")

--- a/api/api.go
+++ b/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/mux"
@@ -9,16 +10,19 @@ import (
 
 //API provides a struct to wrap the api around
 type API struct {
-	Router *mux.Router
+	Router  *mux.Router
+	mongoDB PermissionsStore
 }
 
 //Setup function sets up the api and returns an api
-func Setup(ctx context.Context, r *mux.Router) *API {
+func Setup(ctx context.Context, r *mux.Router, mongoDB PermissionsStore) *API {
 	api := &API{
-		Router: r,
+		Router:  r,
+		mongoDB: mongoDB,
 	}
 
 	log.Event(ctx, "remove hello endpoint")
 	r.HandleFunc("/hello", HelloHandler()).Methods("GET")
+	r.HandleFunc("/role/{id}", api.GetRoleHandler).Methods(http.MethodGet)
 	return api
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,23 +1,28 @@
-package api
+package api_test
 
 import (
 	"context"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ONSdigital/dp-permissions-api/api"
+	"github.com/ONSdigital/dp-permissions-api/api/mock"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestSetup(t *testing.T) {
 	Convey("Given an API instance", t, func() {
+		mongoMock := &mock.PermissionsStoreMock{}
+
 		r := mux.NewRouter()
 		ctx := context.Background()
-		api := Setup(ctx, r)
+		api := api.Setup(ctx, r, mongoMock)
 
 		Convey("When created the following routes should have been added", func() {
 			// Replace the check below with any newly added api endpoints
 			So(hasRoute(api.Router, "/hello", "GET"), ShouldBeTrue)
+			So(hasRoute(api.Router, "/role/{id}", "GET"), ShouldBeTrue)
 		})
 	})
 }

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"context"
+
+	"github.com/ONSdigital/dp-healthcheck/healthcheck"
+	"github.com/ONSdigital/dp-permissions-api/models"
+)
+
+//go:generate moq -out mock/permissionsStore.go -pkg mock . PermissionsStore
+
+//PermissionsStore defines the behaviour of a PermissionsStore
+type PermissionsStore interface {
+	Checker(ctx context.Context, state *healthcheck.CheckState) error
+	Close(ctx context.Context) error
+	GetRole(ctx context.Context, id string) (*models.Role, error)
+}

--- a/api/role.go
+++ b/api/role.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/ONSdigital/dp-permissions-api/mongo"
+	"github.com/ONSdigital/dp-permissions-api/apierrors"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/mux"
 )
@@ -20,7 +20,7 @@ func (api *API) GetRoleHandler(w http.ResponseWriter, req *http.Request) {
 	role, err := api.permissionsStore.GetRole(ctx, roleID)
 	if err != nil {
 		log.Event(ctx, "getRole Handler: retrieving role from mongoDB returned an error", log.ERROR, log.Error(err), logdata)
-		if err == mongo.ErrRoleNotFound {
+		if err == apierrors.ErrRoleNotFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
 		}

--- a/api/role.go
+++ b/api/role.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/ONSdigital/dp-permissions-api/mongo"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/mux"
 )
@@ -19,7 +20,11 @@ func (api *API) GetRoleHandler(w http.ResponseWriter, req *http.Request) {
 	role, err := api.permissionsStore.GetRole(ctx, roleID)
 	if err != nil {
 		log.Event(ctx, "getRole Handler: retrieving role from mongoDB returned an error", log.ERROR, log.Error(err), logdata)
-		http.Error(w, err.Error(), http.StatusNotFound)
+		if err == mongo.ErrRoleNotFound {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 

--- a/api/role.go
+++ b/api/role.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/ONSdigital/log.go/log"
+	"github.com/gorilla/mux"
+)
+
+/*
+//GetRolesHandler is a handler that gets all roles from MongoDB
+func (api *API) GetRolesHandler(w http.ResponseWriter, req *http.Request, mongoConf config.MongoConfiguration) {
+	ctx := req.Context()
+
+	// get roles from MongoDB
+	items, err := api.mongoDB.GetRoles(ctx, mongoConf)
+	if err != nil {
+		log.Event(ctx, "api endpoint getRoles returned an error", log.ERROR, log.Error(err))
+		return nil, err
+	}
+
+	roles := models.Roles{
+		Items:      items,
+		Count:      len(items),
+		Limit:      len(items),
+		TotalCount: len(items),
+	}
+
+	var b []byte
+	b, err = json.Marshal(roles)
+
+}
+*/
+
+//GetRoleHandler is a handler that gets a role by its ID from MongoDB
+func (api *API) GetRoleHandler(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	vars := mux.Vars(req)
+	roleID := vars["id"]
+	logdata := log.Data{"role-id": roleID}
+
+	//get role from mongoDB by id
+	role, err := api.mongoDB.GetRole(ctx, roleID)
+	if err != nil {
+		log.Event(ctx, "getRole Handler: retrieving role from mongoDB returned an error", log.ERROR, log.Error(err), logdata)
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	var b []byte
+	b, err = json.Marshal(role)
+	if err != nil {
+		log.Event(ctx, "getRole Handler: filed to marshal role resource into bytes", log.ERROR, log.Error(err), logdata)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	//Set headers
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+	if _, err := w.Write(b); err != nil {
+		log.Event(ctx, "getRole Handler: error writing bytes to response", log.ERROR, log.Error(err), logdata)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	log.Event(ctx, "getRole Handler: Successfully retrieved role", log.INFO, logdata)
+
+}

--- a/api/role.go
+++ b/api/role.go
@@ -8,31 +8,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-/*
-//GetRolesHandler is a handler that gets all roles from MongoDB
-func (api *API) GetRolesHandler(w http.ResponseWriter, req *http.Request, mongoConf config.MongoConfiguration) {
-	ctx := req.Context()
-
-	// get roles from MongoDB
-	items, err := api.mongoDB.GetRoles(ctx, mongoConf)
-	if err != nil {
-		log.Event(ctx, "api endpoint getRoles returned an error", log.ERROR, log.Error(err))
-		return nil, err
-	}
-
-	roles := models.Roles{
-		Items:      items,
-		Count:      len(items),
-		Limit:      len(items),
-		TotalCount: len(items),
-	}
-
-	var b []byte
-	b, err = json.Marshal(roles)
-
-}
-*/
-
 //GetRoleHandler is a handler that gets a role by its ID from MongoDB
 func (api *API) GetRoleHandler(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()

--- a/api/role.go
+++ b/api/role.go
@@ -16,7 +16,7 @@ func (api *API) GetRoleHandler(w http.ResponseWriter, req *http.Request) {
 	logdata := log.Data{"role-id": roleID}
 
 	//get role from mongoDB by id
-	role, err := api.mongoDB.GetRole(ctx, roleID)
+	role, err := api.permissionsStore.GetRole(ctx, roleID)
 	if err != nil {
 		log.Event(ctx, "getRole Handler: retrieving role from mongoDB returned an error", log.ERROR, log.Error(err), logdata)
 		http.Error(w, err.Error(), http.StatusNotFound)

--- a/api/role_test.go
+++ b/api/role_test.go
@@ -9,12 +9,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ONSdigital/dp-permissions-api/apierrors"
+
 	"github.com/gorilla/mux"
 
 	"github.com/ONSdigital/dp-permissions-api/api"
 	"github.com/ONSdigital/dp-permissions-api/api/mock"
 	"github.com/ONSdigital/dp-permissions-api/models"
-	"github.com/ONSdigital/dp-permissions-api/mongo"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -42,7 +43,7 @@ func TestGetRoleHandler(t *testing.T) {
 				case testRoleID1:
 					return &models.Role{ID: "testRoleID1", Name: "ReadOnly", Permissions: []string{"read"}}, nil
 				default:
-					return nil, mongo.ErrRoleNotFound
+					return nil, apierrors.ErrRoleNotFound
 				}
 			},
 		}

--- a/api/role_test.go
+++ b/api/role_test.go
@@ -1,0 +1,83 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"github.com/ONSdigital/dp-permissions-api/api"
+	"github.com/ONSdigital/dp-permissions-api/api/mock"
+	"github.com/ONSdigital/dp-permissions-api/models"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	testRoleID1 = "roleID1"
+)
+
+var (
+	errRoleNotFound = errors.New("role not found")
+)
+
+func dbRole(id string) *models.Role {
+	return &models.Role{
+		ID:   id,
+		Name: "ReadOnly",
+		Permissions: []string{
+			"read",
+		},
+	}
+}
+
+func TestGetRoleHandler(t *testing.T) {
+
+	Convey("Given a GetRole Handler", t, func() {
+
+		mockedPermissionsStore := &mock.PermissionsStoreMock{
+			GetRoleFunc: func(ctx context.Context, id string) (*models.Role, error) {
+				switch id {
+				case testRoleID1:
+					return &models.Role{ID: "testRoleID1", Name: "ReadOnly", Permissions: []string{"read"}}, nil
+				default:
+					return nil, errRoleNotFound
+				}
+			},
+		}
+
+		permissionsApi := api.Setup(context.Background(), mux.NewRouter(), mockedPermissionsStore)
+
+		Convey("When an existing role is requested with its Role ID", func() {
+
+			r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:25400/role/%s", testRoleID1), nil)
+			w := httptest.NewRecorder()
+			permissionsApi.Router.ServeHTTP(w, r)
+
+			Convey("The the matched role is returned with status code 200", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+				payload, err := ioutil.ReadAll(w.Body)
+				So(err, ShouldBeNil)
+				returnedRole := models.Role{}
+				err = json.Unmarshal(payload, &returnedRole)
+				So(err, ShouldBeNil)
+				So(returnedRole, ShouldResemble, *dbRole("testRoleID1"))
+			})
+		})
+
+		Convey("When a non existing role is requested a Not Found response is returned", func() {
+
+			r := httptest.NewRequest(http.MethodGet, "http://localhost:25400/role/inexistent", nil)
+			w := httptest.NewRecorder()
+			permissionsApi.Router.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, http.StatusNotFound)
+
+		})
+	})
+
+}

--- a/api/role_test.go
+++ b/api/role_test.go
@@ -3,7 +3,6 @@ package api_test
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -15,15 +14,12 @@ import (
 	"github.com/ONSdigital/dp-permissions-api/api"
 	"github.com/ONSdigital/dp-permissions-api/api/mock"
 	"github.com/ONSdigital/dp-permissions-api/models"
+	"github.com/ONSdigital/dp-permissions-api/mongo"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 const (
 	testRoleID1 = "roleID1"
-)
-
-var (
-	errRoleNotFound = errors.New("role not found")
 )
 
 func dbRole(id string) *models.Role {
@@ -46,7 +42,7 @@ func TestGetRoleHandler(t *testing.T) {
 				case testRoleID1:
 					return &models.Role{ID: "testRoleID1", Name: "ReadOnly", Permissions: []string{"read"}}, nil
 				default:
-					return nil, errRoleNotFound
+					return nil, mongo.ErrRoleNotFound
 				}
 			},
 		}

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -1,0 +1,11 @@
+package apierrors
+
+import (
+	"errors"
+)
+
+//A lit of error messages for Permissions API
+var (
+	//ErrRoleNotFound is an error when the role can not be found in mongoDB
+	ErrRoleNotFound = errors.New("role not found")
+)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-mongodb v1.5.0
 	github.com/ONSdigital/dp-net v1.0.11
-	github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58
 	github.com/ONSdigital/log.go v1.0.1
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
@@ -20,4 +19,5 @@ require (
 	golang.org/x/net v0.0.0-20201224014010-6772e930b67b // indirect
 	golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-mongodb v1.5.0
 	github.com/ONSdigital/dp-net v1.0.11
+	github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58
 	github.com/ONSdigital/log.go v1.0.1
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
@@ -14,6 +15,7 @@ require (
 	github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pkg/errors v0.9.1
+	github.com/satori/go.uuid v1.2.0
 	github.com/smartystreets/goconvey v1.6.4
 	golang.org/x/net v0.0.0-20201224014010-6772e930b67b // indirect
 	golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,7 @@ github.com/ONSdigital/dp-net v1.0.10 h1:jtliifmkyRsDlp+pC5pYt9BEHF+DqaoJyTcOuLjA
 github.com/ONSdigital/dp-net v1.0.10/go.mod h1:2lvIKOlD4T3BjWQwjHhBUO2UNWDk82u/+mHRn0R3C9A=
 github.com/ONSdigital/dp-net v1.0.11 h1:BJi+e21NuwEaqANDhEzWeaQgPuoSWkQS49mJALgZJKs=
 github.com/ONSdigital/dp-net v1.0.11/go.mod h1:2lvIKOlD4T3BjWQwjHhBUO2UNWDk82u/+mHRn0R3C9A=
+github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58 h1:XHnzoC7TxueLAfkBpblPiwaIxjngGv1VNVZhvE4jY6w=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=
@@ -56,11 +57,14 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mongo-go/testdb v0.0.0-20190724200850-a72a12eee610/go.mod h1:xyZcxcSxyRLfj4CDZzyycsGRcwfpY07ncmD2keFr548=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
+github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,7 @@ github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQ
 github.com/ONSdigital/log.go v1.0.1-0.20200805145532-1f25087a0744/go.mod h1:y4E9MYC+cV9VfjRD0UBGj8PA7H3wABqQi87/ejrDhYc=
 github.com/ONSdigital/log.go v1.0.1 h1:SZ5wRZAwlt2jQUZ9AUzBB/PL+iG15KapfQpJUdA18/4=
 github.com/ONSdigital/log.go v1.0.1/go.mod h1:dIwSXuvFB5EsZG5x44JhsXZKMd80zlb0DZxmiAtpL4M=
+github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9 h1:wWke/RUCl7VRjQhwPlR/v0glZXNYzBHdNUzf/Am2Nmg=
 github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9/go.mod h1:uPmAp6Sws4L7+Q/OokbWDAK1ibXYhB3PXFP1kol5hPg=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
@@ -32,6 +33,7 @@ github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 h1:DujepqpGd1hyOd7a
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
@@ -46,6 +48,7 @@ github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNE
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -60,6 +63,7 @@ github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyex
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mongo-go/testdb v0.0.0-20190724200850-a72a12eee610/go.mod h1:xyZcxcSxyRLfj4CDZzyycsGRcwfpY07ncmD2keFr548=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -100,6 +104,10 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262 h1:qsl9y/CJx34tuA7QCPNp86JNJe4spst6Ff8MjvPUdPg=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 h1:VpOs+IwYnYBaFnrNAeB8UUWtL3vEUnzSCL1nVjPhqrw=
 gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/import-roles/import-roles.go
+++ b/import-roles/import-roles.go
@@ -9,10 +9,12 @@ import (
 
 	"github.com/ONSdigital/log.go/log"
 	"github.com/globalsign/mgo"
+	uuid "github.com/satori/go.uuid"
 )
 
 //Role represents a role that will be stored in mongo
 type Role struct {
+	ID          string   `bson:"_id" json:"id"`
 	Name        string   `bson:"name" json:"name"`
 	Permissions []string `bson:"permissions" json:"permissions"`
 }
@@ -58,6 +60,7 @@ func main() {
 
 	for _, role := range res {
 
+		role.ID = uuid.NewV4().String()
 		logData := log.Data{"role": role}
 
 		if err = session.DB("permissions").C("permissions").Insert(role); err != nil {

--- a/import-roles/import-roles.go
+++ b/import-roles/import-roles.go
@@ -7,17 +7,11 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/ONSdigital/dp-permissions-api/models"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/globalsign/mgo"
 	uuid "github.com/satori/go.uuid"
 )
-
-//Role represents a role that will be stored in mongo
-type Role struct {
-	ID          string   `bson:"_id" json:"id"`
-	Name        string   `bson:"name" json:"name"`
-	Permissions []string `bson:"permissions" json:"permissions"`
-}
 
 func main() {
 
@@ -51,7 +45,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	res := []Role{}
+	res := []models.Role{}
 	if err := json.Unmarshal(b, &res); err != nil {
 		logData := log.Data{"json file": res}
 		log.Event(ctx, "failed to unmarshal json", log.ERROR, log.Error(err), logData)

--- a/models/role.go
+++ b/models/role.go
@@ -1,0 +1,17 @@
+package models
+
+//Roles represents an array of the role model
+type Roles struct {
+	Count      int    `json:"count"`
+	Offset     int    `json:"offset"`
+	Limit      int    `json:"limit"`
+	Items      []Role `json:"items"`
+	TotalCount int    `json:"total_count"`
+}
+
+//Role represents the structure for a role
+type Role struct {
+	ID          string   `bson:"_id"`
+	Name        string   `bson:"name" json:"name"`
+	Permissions []string `bson:"permissions" json:"permissions"`
+}

--- a/models/role.go
+++ b/models/role.go
@@ -11,7 +11,7 @@ type Roles struct {
 
 //Role represents the structure for a role
 type Role struct {
-	ID          string   `bson:"_id"`
+	ID          string   `bson:"_id" json:"id"`
 	Name        string   `bson:"name" json:"name"`
 	Permissions []string `bson:"permissions" json:"permissions"`
 }

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -72,7 +72,7 @@ func (m *Mongo) Checker(ctx context.Context, state *healthcheck.CheckState) erro
 func (m *Mongo) GetRole(ctx context.Context, id string) (*models.Role, error) {
 	s := m.Session.Copy()
 	defer s.Close()
-	log.Event(ctx, "getting role by ID", log.Data{"id": id})
+	log.Event(ctx, "getting role by ID", log.INFO, log.Data{"id": id})
 
 	var role models.Role
 	err := s.DB(m.Database).C(m.Collection).Find(bson.M{"_id": id}).One(&role)

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/ONSdigital/dp-permissions-api/apierrors"
+
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dpMongodb "github.com/ONSdigital/dp-mongodb"
 	dpMongoHealth "github.com/ONSdigital/dp-mongodb/health"
@@ -21,11 +23,6 @@ type Mongo struct {
 	Database     string
 	Collection   string
 }
-
-var (
-	//ErrRoleNotFound is an error when the role can not be found in mongoDB
-	ErrRoleNotFound = errors.New("role not found")
-)
 
 //Init creates a new mgo.Session with a strong consistency and a write mode of "majority"
 func (m *Mongo) Init(mongoConf config.MongoConfiguration) (err error) {
@@ -79,7 +76,7 @@ func (m *Mongo) GetRole(ctx context.Context, id string) (*models.Role, error) {
 	err := s.DB(m.Database).C(m.Collection).Find(bson.M{"_id": id}).One(&role)
 	if err != nil {
 		if err == mgo.ErrNotFound {
-			return nil, ErrRoleNotFound
+			return nil, apierrors.ErrRoleNotFound
 		}
 		return nil, err
 	}

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -4,19 +4,27 @@ import (
 	"context"
 	"errors"
 
-	"github.com/ONSdigital/dp-permissions-api/config"
-
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dpMongodb "github.com/ONSdigital/dp-mongodb"
 	dpMongoHealth "github.com/ONSdigital/dp-mongodb/health"
+	"github.com/ONSdigital/dp-permissions-api/config"
+	"github.com/ONSdigital/dp-permissions-api/models"
+	"github.com/ONSdigital/log.go/log"
 	"github.com/globalsign/mgo"
+	"gopkg.in/mgo.v2/bson"
 )
 
 //Mongo represents a simplistic MongoDB configuration, with session and health client
 type Mongo struct {
 	Session      *mgo.Session
 	healthClient *dpMongoHealth.CheckMongoClient
+	Database     string
+	Collection   string
 }
+
+var (
+	errRoleNotFound = errors.New("role not found")
+)
 
 //Init creates a new mgo.Session with a strong consistency and a write mode of "majority"
 func (m *Mongo) Init(mongoConf config.MongoConfiguration) (err error) {
@@ -30,6 +38,9 @@ func (m *Mongo) Init(mongoConf config.MongoConfiguration) (err error) {
 	}
 	m.Session.EnsureSafe(&mgo.Safe{WMode: "majority"})
 	m.Session.SetMode(mgo.Strong, true)
+
+	m.Database = mongoConf.Database
+	m.Collection = mongoConf.Collection
 
 	databaseCollectionBuilder := make(map[dpMongoHealth.Database][]dpMongoHealth.Collection)
 	databaseCollectionBuilder[(dpMongoHealth.Database)(mongoConf.Database)] = []dpMongoHealth.Collection{(dpMongoHealth.Collection)(mongoConf.Collection)}
@@ -55,4 +66,22 @@ func (m *Mongo) Close(ctx context.Context) error {
 // Checker is called by the healthcheck library to check the health state of this mongoDB instance
 func (m *Mongo) Checker(ctx context.Context, state *healthcheck.CheckState) error {
 	return m.healthClient.Checker(ctx, state)
+}
+
+//GetRole retrieves a role document by its ID
+func (m *Mongo) GetRole(ctx context.Context, id string) (*models.Role, error) {
+	s := m.Session.Copy()
+	defer s.Close()
+	log.Event(ctx, "getting role by ID", log.Data{"id": id})
+
+	var role models.Role
+	err := s.DB(m.Database).C(m.Collection).Find(bson.M{"_id": id}).One(&role)
+	if err != nil {
+		if err == mgo.ErrNotFound {
+			return nil, errRoleNotFound
+		}
+		return nil, err
+	}
+
+	return &role, nil
 }

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -23,7 +23,8 @@ type Mongo struct {
 }
 
 var (
-	errRoleNotFound = errors.New("role not found")
+	//ErrRoleNotFound is an error when the role can not be found in mongoDB
+	ErrRoleNotFound = errors.New("role not found")
 )
 
 //Init creates a new mgo.Session with a strong consistency and a write mode of "majority"
@@ -78,7 +79,7 @@ func (m *Mongo) GetRole(ctx context.Context, id string) (*models.Role, error) {
 	err := s.DB(m.Database).C(m.Collection).Find(bson.M{"_id": id}).One(&role)
 	if err != nil {
 		if err == mgo.ErrNotFound {
-			return nil, errRoleNotFound
+			return nil, ErrRoleNotFound
 		}
 		return nil, err
 	}

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/ONSdigital/dp-permissions-api/api"
 	"github.com/ONSdigital/dp-permissions-api/config"
 	"github.com/ONSdigital/dp-permissions-api/mongo"
 
@@ -53,7 +54,7 @@ func (e *Init) DoGetHTTPServer(bindAddr string, router http.Handler) HTTPServer 
 }
 
 // GetMongoDB creates a mongoDB client and sets the Mongo flag to true
-func (e *ExternalServiceList) GetMongoDB(ctx context.Context, cfg *config.Config) (PermissionsStore, error) {
+func (e *ExternalServiceList) GetMongoDB(ctx context.Context, cfg *config.Config) (api.PermissionsStore, error) {
 	mongoDB, err := e.Init.DoGetMongoDB(ctx, cfg)
 	if err != nil {
 		return nil, err
@@ -73,7 +74,7 @@ func (e *Init) DoGetHealthCheck(cfg *config.Config, buildTime, gitCommit, versio
 }
 
 // DoGetMongoDB returns a MongoDB
-func (e *Init) DoGetMongoDB(ctx context.Context, cfg *config.Config) (PermissionsStore, error) {
+func (e *Init) DoGetMongoDB(ctx context.Context, cfg *config.Config) (api.PermissionsStore, error) {
 	mongodb := &mongo.Mongo{}
 	if err := mongodb.Init(cfg.MongoConfig); err != nil {
 		return nil, err

--- a/service/initialise_test.go
+++ b/service/initialise_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ONSdigital/dp-permissions-api/api"
+	apiMock "github.com/ONSdigital/dp-permissions-api/api/mock"
 	"github.com/ONSdigital/dp-permissions-api/config"
 	"github.com/ONSdigital/dp-permissions-api/service"
 	"github.com/ONSdigital/dp-permissions-api/service/mock"
@@ -161,10 +163,10 @@ func TestGetMongoDB(t *testing.T) {
 
 	Convey("Given a service list that returns a mocked mongo permissions store", t, func() {
 
-		mongoMock := &mock.PermissionsStoreMock{}
+		mongoMock := &apiMock.PermissionsStoreMock{}
 
 		newServiceMock := &mock.InitialiserMock{
-			DoGetMongoDBFunc: func(ctx context.Context, cfg *config.Config) (service.PermissionsStore, error) {
+			DoGetMongoDBFunc: func(ctx context.Context, cfg *config.Config) (api.PermissionsStore, error) {
 				return mongoMock, nil
 			},
 		}
@@ -183,7 +185,7 @@ func TestGetMongoDB(t *testing.T) {
 	Convey("Given a service list that returns nil for mongo permissions store", t, func() {
 
 		newServiceMock := &mock.InitialiserMock{
-			DoGetMongoDBFunc: func(ctx context.Context, cfg *config.Config) (service.PermissionsStore, error) {
+			DoGetMongoDBFunc: func(ctx context.Context, cfg *config.Config) (api.PermissionsStore, error) {
 				return nil, errMongoDB
 			},
 		}

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -5,19 +5,19 @@ import (
 	"net/http"
 
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
+	"github.com/ONSdigital/dp-permissions-api/api"
 	"github.com/ONSdigital/dp-permissions-api/config"
 )
 
 //go:generate moq -out mock/initialiser.go -pkg mock . Initialiser
 //go:generate moq -out mock/server.go -pkg mock . HTTPServer
 //go:generate moq -out mock/healthCheck.go -pkg mock . HealthChecker
-//go:generate moq -out mock/permissionsStore.go -pkg mock . PermissionsStore
 
 // Initialiser defines the methods to initialise external services
 type Initialiser interface {
 	DoGetHTTPServer(bindAddr string, router http.Handler) HTTPServer
 	DoGetHealthCheck(cfg *config.Config, buildTime, gitCommit, version string) (HealthChecker, error)
-	DoGetMongoDB(ctx context.Context, cfg *config.Config) (PermissionsStore, error)
+	DoGetMongoDB(ctx context.Context, cfg *config.Config) (api.PermissionsStore, error)
 }
 
 // HTTPServer defines the required methods from the HTTP server
@@ -32,10 +32,4 @@ type HealthChecker interface {
 	Start(ctx context.Context)
 	Stop()
 	AddCheck(name string, checker healthcheck.Checker) (err error)
-}
-
-//PermissionsStore defines the behaviour of a PermissionsStore
-type PermissionsStore interface {
-	Checker(ctx context.Context, state *healthcheck.CheckState) error
-	Close(ctx context.Context) error
 }

--- a/service/mock/initialiser.go
+++ b/service/mock/initialiser.go
@@ -5,6 +5,7 @@ package mock
 
 import (
 	"context"
+	"github.com/ONSdigital/dp-permissions-api/api"
 	"github.com/ONSdigital/dp-permissions-api/config"
 	"github.com/ONSdigital/dp-permissions-api/service"
 	"net/http"
@@ -27,7 +28,7 @@ var _ service.Initialiser = &InitialiserMock{}
 //             DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
 // 	               panic("mock out the DoGetHealthCheck method")
 //             },
-//             DoGetMongoDBFunc: func(ctx context.Context, cfg *config.Config) (service.PermissionsStore, error) {
+//             DoGetMongoDBFunc: func(ctx context.Context, cfg *config.Config) (api.PermissionsStore, error) {
 // 	               panic("mock out the DoGetMongoDB method")
 //             },
 //         }
@@ -44,7 +45,7 @@ type InitialiserMock struct {
 	DoGetHealthCheckFunc func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error)
 
 	// DoGetMongoDBFunc mocks the DoGetMongoDB method.
-	DoGetMongoDBFunc func(ctx context.Context, cfg *config.Config) (service.PermissionsStore, error)
+	DoGetMongoDBFunc func(ctx context.Context, cfg *config.Config) (api.PermissionsStore, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -158,7 +159,7 @@ func (mock *InitialiserMock) DoGetHealthCheckCalls() []struct {
 }
 
 // DoGetMongoDB calls DoGetMongoDBFunc.
-func (mock *InitialiserMock) DoGetMongoDB(ctx context.Context, cfg *config.Config) (service.PermissionsStore, error) {
+func (mock *InitialiserMock) DoGetMongoDB(ctx context.Context, cfg *config.Config) (api.PermissionsStore, error) {
 	if mock.DoGetMongoDBFunc == nil {
 		panic("InitialiserMock.DoGetMongoDBFunc: method is nil but Initialiser.DoGetMongoDB was just called")
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -15,10 +15,10 @@ type Service struct {
 	Config      *config.Config
 	Server      HTTPServer
 	Router      *mux.Router
-	Api         *api.API
+	api         *api.API
 	ServiceList *ExternalServiceList
 	HealthCheck HealthChecker
-	MongoDB     PermissionsStore
+	MongoDB     api.PermissionsStore
 }
 
 // Run the service
@@ -41,7 +41,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	}
 
 	// Setup the API
-	a := api.Setup(ctx, r)
+	a := api.Setup(ctx, r, mongoDB)
 
 	hc, err := serviceList.GetHealthCheck(cfg, buildTime, gitCommit, version)
 
@@ -67,7 +67,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	return &Service{
 		Config:      cfg,
 		Router:      r,
-		Api:         a,
+		api:         a,
 		HealthCheck: hc,
 		ServiceList: serviceList,
 		Server:      s,
@@ -128,7 +128,7 @@ func (svc *Service) Close(ctx context.Context) error {
 
 func registerCheckers(ctx context.Context,
 	hc HealthChecker,
-	mongoDB PermissionsStore) (err error) {
+	mongoDB api.PermissionsStore) (err error) {
 
 	hasErrors := false
 


### PR DESCRIPTION
### What

- Create model of role and mongoDB read to retrieve a role by its ID
- Create get role by ID handler
- Add route for get role
- Add tests
- Update utility to load roles into mongo, so an ID is generated. This was done so the _id field in Mongo was a string.
- Regenerated the mocks. This was done because the PermissionsStore interface was moved into the API package, to prevent cyclic imports
- To prevent passing the config into the GetRole method in the mongo package, database and collection were added to the Mongo struct

### How to review
- I would be grateful for feedback on how the code and packages have been structured
- Check that the test pass
- If you would like to run the application. The roles can be loaded into MongoDB using the utility, and then you can try to get one of the roles using the endpoint.

### Who can review

Anyone