### PR TITLE
use standard http server for component tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,7 @@ convey:
 .PHONY: test-component
 test-component:
 	go test -race -cover -coverprofile="coverage.txt" -coverpkg=github.com/ONSdigital/dp-permissions-api/... -component
+
+.PHONY: lint
+lint:
+	exit

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -12,4 +12,4 @@ inputs:
   - name: dp-permissions-api
 
 run:
-  path: dp-topic-api/ci/scripts/component.sh
+  path: dp-permissions-api/ci/scripts/component.sh

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -1,0 +1,18 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: golang
+    tag: 1.15.2
+
+inputs:
+  - name: dp-permissions-api
+
+caches:
+  - path: go/
+
+run:
+  path: dp-permissions-api/ci/scripts/lint.sh

--- a/ci/scripts/lint.sh
+++ b/ci/scripts/lint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -eux
+
+pushd dp-permissions-api
+  make lint
+popd

--- a/features/steps/permissions_component.go
+++ b/features/steps/permissions_component.go
@@ -7,7 +7,6 @@ import (
 	componenttest "github.com/ONSdigital/dp-component-test"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dpMongoDriver "github.com/ONSdigital/dp-mongodb/v2/mongodb"
-	dphttp "github.com/ONSdigital/dp-net/http"
 	"github.com/ONSdigital/dp-permissions-api/api"
 	"github.com/ONSdigital/dp-permissions-api/config"
 	"github.com/ONSdigital/dp-permissions-api/mongo"
@@ -27,14 +26,14 @@ type PermissionsComponent struct {
 	errorChan      chan error
 	MongoClient    *mongo.Mongo
 	Config         *config.Config
-	HTTPServer     *dphttp.Server
+	HTTPServer     *http.Server
 	ServiceRunning bool
 }
 // NewPermissionsComponent initializes mock server and inmemory mongodb used for running component tests.
 func NewPermissionsComponent(mongoFeature *componenttest.MongoFeature) (*PermissionsComponent, error) {
 
 	f := &PermissionsComponent{
-		HTTPServer:     &dphttp.Server{},
+		HTTPServer:     &http.Server{},
 		errorChan:      make(chan error),
 		ServiceRunning: false,
 	}


### PR DESCRIPTION
### What

Use standard http server for component tests.

### How to review

Validate component tests are running locally by executing `make test-component`.

### Who can review

Anyone.
