### PR TITLE
Extend health deadline in nomad to 5 mins.

### DIFF
--- a/dp-permissions-api.nomad
+++ b/dp-permissions-api.nomad
@@ -6,7 +6,7 @@ job "dp-permissions-api" {
   update {
     stagger          = "60s"
     min_healthy_time = "30s"
-    healthy_deadline = "2m"
+    healthy_deadline = "5m"
     max_parallel     = 1
     auto_revert      = true
   }


### PR DESCRIPTION
### What

As per title.

### How to review

Ensure `nomad.healthy_deadline` deadline is set to `5m`, checks and tests pass.

### Who can review

!me
