### PR TITLE
Feature/extend permission model conditionals

### DIFF
--- a/features/delete_policies.feature
+++ b/features/delete_policies.feature
@@ -29,7 +29,7 @@ Feature: Behaviour of application when performing requests against /v1/policies 
               ],
               "conditions": [
                   {
-                      "operator": "=",
+                      "operator": "StringEquals",
                       "attributes": [
                         "collection-id"
                       ],

--- a/features/get_permissions_bundle.feature
+++ b/features/get_permissions_bundle.feature
@@ -54,7 +54,7 @@ Feature: GET /v1/permissions-bundle endpoint
                     ],
                     "conditions": [
                         {
-                            "operator": "=",
+                            "operator": "StringEquals",
                             "attributes": [
                               "collection-id"
                             ],
@@ -93,7 +93,7 @@ Feature: GET /v1/permissions-bundle endpoint
                         "attributes": [
                           "collection-id"
                         ],
-                        "operator": "=",
+                        "operator": "StringEquals",
                         "values": [
                           "collection-765"
                         ]

--- a/features/get_policies.feature
+++ b/features/get_policies.feature
@@ -29,7 +29,7 @@ Feature: Behaviour of application when performing requests against /v1/policies 
               ],
               "conditions": [
                   {
-                      "operator": "=",
+                      "operator": "StringEquals",
                       "attributes": [
                         "collection-id"
                       ],
@@ -78,7 +78,7 @@ Feature: Behaviour of application when performing requests against /v1/policies 
               ],
               "conditions": [
                   {
-                      "operator": "=",
+                      "operator": "StringEquals",
                       "attributes": [
                         "collection-id"
                       ],

--- a/features/post_policies.feature
+++ b/features/post_policies.feature
@@ -15,7 +15,7 @@ Feature: Behaviour of application when doing the POST /v1/policies endpoint, usi
               "attributes": [
                 "a1"
               ],
-              "operator": "and",
+              "operator": "StringEquals",
               "values": [
                 "v1"
               ]
@@ -51,7 +51,7 @@ Feature: Behaviour of application when doing the POST /v1/policies endpoint, usi
               "attributes": [
                 "a1"
               ],
-              "operator": "and",
+              "operator": "StringEquals",
               "values": [
                 "v1"
               ]
@@ -77,7 +77,7 @@ Feature: Behaviour of application when doing the POST /v1/policies endpoint, usi
               "attributes": [
                 "a1"
               ],
-              "operator": "and",
+              "operator": "StringEquals",
               "values": [
                 "v1"
               ]
@@ -106,7 +106,7 @@ Feature: Behaviour of application when doing the POST /v1/policies endpoint, usi
               "attributes": [
                 "a1"
               ],
-              "operator": "and",
+              "operator": "StringEquals",
               "values": [
                 "v1"
               ]
@@ -133,7 +133,7 @@ Feature: Behaviour of application when doing the POST /v1/policies endpoint, usi
               "attributes": [
                 "a1"
               ],
-              "operator": "and",
+              "operator": "StringEquals",
               "values": [
                 "v1"
               ]
@@ -159,7 +159,7 @@ Feature: Behaviour of application when doing the POST /v1/policies endpoint, usi
               "attributes": [
                 "a1"
               ],
-              "operator": "and",
+              "operator": "StringEquals",
               "values": [
                 "v1"
               ]

--- a/import-script/policies.json
+++ b/import-script/policies.json
@@ -26,7 +26,7 @@
         "attributes": [
           "role"
         ],
-        "operator": "=",
+        "operator": "StringEquals",
         "values": [
           "collection-previewer"
         ]

--- a/permissions/bundler_test.go
+++ b/permissions/bundler_test.go
@@ -3,11 +3,12 @@ package permissions_test
 import (
 	"context"
 	"errors"
+	"testing"
+
 	"github.com/ONSdigital/dp-permissions-api/models"
 	"github.com/ONSdigital/dp-permissions-api/permissions"
 	"github.com/ONSdigital/dp-permissions-api/permissions/mock"
 	. "github.com/smartystreets/goconvey/convey"
-	"testing"
 )
 
 func TestBundler_Get(t *testing.T) {
@@ -37,7 +38,7 @@ func TestBundler_Get(t *testing.T) {
 		Conditions: []models.Condition{
 			{
 				Attributes: []string{"collection-id"},
-				Operator:   "=",
+				Operator:   models.OperatorStringEquals,
 				Values:     []string{"collection-765"},
 			},
 		},

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -336,7 +336,8 @@ definitions:
       operator:
         description: "operator of the condition"
         type: string
-        example: "equals"
+        enum: [StringEquals, StartsWith]
+        example: "StringEquals"
       values:
         description: "List of truth condition values"
         type: array
@@ -427,7 +428,7 @@ definitions:
             conditions:
               - attributes:
                   - collection-id
-                operator: '='
+                operator: 'StringEquals'
                 values:
                   - collection-765
 


### PR DESCRIPTION
### What

Condition operators changed from symbol to keyword based and are now validated during policy validation. '=' condition operator changed to 'StringEquals' and support for new 'StartsWith' operator added. Keyword operators are case-sensitive.

### How to review

Review code changes inc. operators implemented as a string enum. Check unit tests.  Review swagger.

### Who can review

Anyone
