### PR TITLE
Changed headers to use http.Header.  Fixed spelling of Authorization.

### DIFF
--- a/sdk/api_client.go
+++ b/sdk/api_client.go
@@ -6,14 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	dphttp "github.com/ONSdigital/dp-net/v2/http"
 	"github.com/ONSdigital/dp-permissions-api/models"
 )
-
-type header string
 
 // package level constants
 const (
@@ -22,14 +19,14 @@ const (
 	policyEndpoint           = "%s/v1/policies/%s" // Delete policy
 	rolesEndpoint            = "%s/v1/roles"       // Add roles
 	getRoleEndpoint          = "%s/v1/roles/%s"    // Get roles
-	Authorisation     header = "Authorisation"     // List of available headers
+	Authorization     string = "Authorization"
 )
 
 // setHeaders adds authorisation header to request
-func setHeaders(req *http.Request, headers map[header][]string) {
-	for h := range headers {
-		for i := range h {
-			req.Header.Add(string(h), headers[h][i])
+func setHeaders(req *http.Request, headers http.Header) {
+	for name, values := range headers {
+		for _, value := range values {
+			req.Header.Add(name, value)
 		}
 	}
 }
@@ -48,7 +45,7 @@ type APIClient struct {
 
 // Options is a struct containing for customised options for the API client
 type Options struct {
-	Headers map[header][]string
+	Headers http.Header
 }
 
 // NewClient constructs a new APIClient instance with a default http client and Options.
@@ -367,12 +364,12 @@ func getResponseBytes(reader io.Reader) ([]byte, error) {
 		return nil, ErrGetPermissionsResponseBodyNil
 	}
 
-	b, err := ioutil.ReadAll(reader)
+	b, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}
 
-	if b == nil || len(b) == 0 {
+	if len(b) == 0 {
 		return nil, ErrGetPermissionsResponseBodyNil
 	}
 

--- a/sdk/api_client_test.go
+++ b/sdk/api_client_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"github.com/ONSdigital/dp-permissions-api/models"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -52,7 +52,7 @@ func TestAPIClient_GetPermissionsBundle(t *testing.T) {
 
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(bytes.NewReader(getExampleBundleJson())),
+					Body:       io.NopCloser(bytes.NewReader(getExampleBundleJson())),
 				}, nil
 			},
 		}
@@ -96,12 +96,12 @@ func TestAPIClient_GetPermissionsBundle_SucceedsOnSecondAttempt(t *testing.T) {
 					retryCount++
 					return &http.Response{
 						StatusCode: http.StatusInternalServerError,
-						Body:       ioutil.NopCloser(strings.NewReader(`bad response`)),
+						Body:       io.NopCloser(strings.NewReader(`bad response`)),
 					}, nil
 				}
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(bytes.NewReader(getExampleBundleJson())),
+					Body:       io.NopCloser(bytes.NewReader(getExampleBundleJson())),
 				}, nil
 			},
 		}
@@ -228,7 +228,7 @@ func TestAPIClient_GetPermissionsBundle_UnexpectedResponseBody(t *testing.T) {
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`bad response`)),
+					Body:       io.NopCloser(strings.NewReader(`bad response`)),
 				}, nil
 			},
 		}
@@ -303,7 +303,7 @@ func TestAPIClient_GetRoles(t *testing.T) {
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(bytes.NewReader(bresult)),
+					Body:       io.NopCloser(bytes.NewReader(bresult)),
 				}, nil
 			},
 		}
@@ -451,7 +451,7 @@ func TestAPIClient_GetRole(t *testing.T) {
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(bytes.NewReader(bresult)),
+					Body:       io.NopCloser(bytes.NewReader(bresult)),
 				}, nil
 			},
 		}
@@ -614,7 +614,7 @@ func TestAPIClient_PostPolicy(t *testing.T) {
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(bytes.NewReader(bresult)),
+					Body:       io.NopCloser(bytes.NewReader(bresult)),
 				}, nil
 			},
 		}
@@ -731,7 +731,7 @@ func TestAPIClient_DeletePolicy(t *testing.T) {
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+					Body:       io.NopCloser(bytes.NewReader([]byte{})),
 				}, nil
 			},
 		}
@@ -852,7 +852,7 @@ func TestAPIClient_GetPolicy(t *testing.T) {
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(bytes.NewReader(bresult)),
+					Body:       io.NopCloser(bytes.NewReader(bresult)),
 				}, nil
 			},
 		}
@@ -969,7 +969,7 @@ func TestAPIClient_PutPolicy(t *testing.T) {
 			DoFunc: func(ctx context.Context, req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+					Body:       io.NopCloser(bytes.NewReader([]byte{})),
 				}, nil
 			},
 		}


### PR DESCRIPTION
### What

You can't set headers if the type isn't exported.  Given the type is actually just http.Header, just used that.

### How to review

Try and consume the prior commit.

### Who can review

!me
