### PR TITLE
fix distro issues per nomad/startup error:

### DIFF
--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.21.5
+    tag: 1.21.5-bullseye
 
 inputs:
   - name: dp-permissions-api

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.21.5
+    tag: 1.21.5-bullseye
 
 inputs:
   - name: dp-permissions-api

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.21.5
+    tag: 1.21.5-bullseye
 
 inputs:
   - name: dp-permissions-api


### PR DESCRIPTION
```
./dp-permissions-api: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./dp-permissions-api)
./dp-permissions-api: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./dp-permissions-api)
```