### PR TITLE
Add /service to Dockerfile as safe directory for git

### DIFF
--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -5,4 +5,6 @@ RUN apt-get update && apt-get upgrade -y
 WORKDIR /service
 CMD tail -f /dev/null
 
+RUN git config --global --add safe.directory /service
+
 FROM build as test


### PR DESCRIPTION
### What

Jira ticket: https://jira.ons.gov.uk/browse/DIS-1857

It was not possible to run the auth stack, using colima, due to a 'dubious ownership' error that was appearing in the docker logs for both the permissions api and the files api. This PR solves the problem in the permissions api.

### How to review

To test the permissions api you will also need to switch your local files api to use this branch (unless it's been merged in already): https://github.com/ONSdigital/dp-files-api/tree/fix/dubious-ownership-error

Run the auth stack using colima, as follows:

- connect to sandbox
aws sso login --profile=dp-sandbox
dp remote allow sandbox

- start colima, using enough memory for the stack
colima start --cpu 4 --memory 8 --disk 100

- move into the auth directory
cd dp-compose/v2/stacks/auth

- update the AWS credentials in local.env
E.g. AWS_ACCESS_KEY_ID="..................."
AWS_SECRET_ACCESS_KEY="......................"
AWS_SESSION_TOKEN="............."

- bring up the auth stack (you may need to do 'make clean' first)
make up

- After some time check to see whether all the services are up and healthy
make health

You should see that all the services are healthy including the permissions api

For further testing, if desired, you could go to http://localhost:8081/florence/login, create a manual collection, and publish it.

### Who can review

Anyone but me.