### PR TITLE
Release/1.4.0

### DIFF
--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -1,4 +1,4 @@
-FROM golang:1.24.1-bullseye as build
+FROM golang:1.24.6 as build
 
 RUN apt-get update && apt-get upgrade -y
 

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.1-bullseye
+    tag: 1.24.6-bookworm
 
 inputs:
   - name: dp-permissions-api

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.1-bullseye
+    tag: 1.24.6-bookworm
 
 inputs:
   - name: dp-permissions-api

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-node-go
-    tag: 1.24.1-bullseye-node-20
+    tag: 1.24.6-bookworm-node-20
 
 inputs:
   - name: dp-permissions-api

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.1-bullseye
+    tag: 1.24.6-bookworm
 
 inputs:
   - name: dp-permissions-api

--- a/import-script/policies.json
+++ b/import-script/policies.json
@@ -53,5 +53,17 @@
     ],
     "role": "files-reader",
     "condition": {}
-  }
+  },
+  {
+    "id" : "bundle-scheduler",
+    "entities" : [ 
+        "users/dis-bundle-scheduler"
+    ],
+    "role" : "bundle-scheduler-admin",
+    "condition" : {
+        "attribute" : "",
+        "operator" : "",
+        "Values" : null
+    }
+}
 ]

--- a/import-script/roles.json
+++ b/import-script/roles.json
@@ -90,5 +90,12 @@
     "permissions": [
       "static-files:read"
     ]
-  }
+  },
+ {
+    "name" : "bundle-scheduler-admin",
+    "permissions" : [ 
+        "bundles:read", 
+        "bundles:update"
+    ]
+}
 ]


### PR DESCRIPTION
### What

- Upgrade golang to 1.24.6-bookworm
- [Adding dis-bundle-scheduler permissions](https://github.com/ONSdigital/dp-permissions-api/commit/1d8899ff03d6182e0a4858a12b5c8b558de0a682)

### How to review

Check release is ok

### Who can review

!Me
