### PR TITLE
add zebedee and dataset-api to files admin

### DIFF
--- a/import-script/policies.json
+++ b/import-script/policies.json
@@ -32,7 +32,9 @@
   {
     "id": "files-admin",
     "entities": [
-      "users/dp-upload-service"
+      "users/dp-upload-service", 
+      "users/zebedee", 
+      "users/dp-dataset-api"
     ],
     "role": "files-admin",
     "condition": {}


### PR DESCRIPTION
### What

- Include zebedee and dataset-api within files-admin policy to match other environments. This is needed since auth has been enabled in dp-files-api and changes were needed within the permissions database

### How to review

- When running `make up-with-seed` for the `dataset-catalogue` the permissions import script is run and these changes should show in the permissions database
- These changes match with prod

### Who can review

Anyone
