### PR TITLE
Switch to dis vulncheck

### DIFF
--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -1,4 +1,4 @@
-FROM golang:1.24.7 as build
+FROM golang:1.24 as build
 
 RUN apt-get update && apt-get upgrade -y
 

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -1,4 +1,4 @@
-FROM golang:1.24.6 as build
+FROM golang:1.24.7 as build
 
 RUN apt-get update && apt-get upgrade -y
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: audit lint test build
 
 .PHONY: audit
 audit:
-	go list -m all | nancy sleuth
+	dis-vulncheck
 
 .PHONY: build
 build:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ To run some of our tests you will need additional tooling:
 
 We use `dis-vulncheck` to do auditing, which you will [need to install](https://github.com/ONSdigital/dis-vulncheck).
 
+#### Linting
+
+We use v2 of golangci-lint, which you will [need to install](https://golangci-lint.run/docs/welcome/install).
+
 ### Dependencies
 
 * run mongo DB locally on 27017 with:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ API for managing access control permissions for Digital Publishing API resources
   steps in the [README](./import-script/README.md).
 * Run `make debug`
 
+## Tools
+
+To run some of our tests you will need additional tooling:
+
+### Audit
+
+We use `dis-vulncheck` to do auditing, which you will [need to install](https://github.com/ONSdigital/dis-vulncheck).
+
 ### Dependencies
 
 * run mongo DB locally on 27017 with:

--- a/ci/audit.yml
+++ b/ci/audit.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: onsdigital/dp-concourse-tools-nancy
+    repository: onsdigital/dp-concourse-tools-vulncheck
     tag: latest
 
 inputs:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/dp-permissions-api
 
-go 1.25
+go 1.24.0
 
 require (
 	github.com/ONSdigital/dp-authorisation/v2 v2.32.3


### PR DESCRIPTION
### What

Jira ticket: https://officefornationalstatistics.atlassian.net/jira/software/c/projects/DIS/boards/1824?selectedIssue=DIS-3854

Upgrading to use dis-vulncheck instead of nancy. This is to avoid the problem of authenticating into OSS Index.

I've also changed the version of go to 1.24 to avoid this issue: https://github.com/golang/go/issues/75584

### How to review

Sense check and make sure that tests pass.

### Who can review

Anyone in Open Sauce.