### PR TITLE
Correct bson values for JSON

### DIFF
--- a/import-script/policies.json
+++ b/import-script/policies.json
@@ -133,7 +133,7 @@
     "condition": {
       "attribute": "collection_type",
       "operator": "StringEquals",
-      "values": [
+      "Values": [
         "automated"
       ]
     }


### PR DESCRIPTION
### What

This value is case sensitive. We should really correct this properly. 

### How to review

Check it matches policies.go:L34

### Who can review

Not me. 