### PR TITLE
Feature/bump go 1.26.2

### DIFF
--- a/.dis-vulncheck.yml
+++ b/.dis-vulncheck.yml
@@ -1,0 +1,6 @@
+---
+ignore:
+  - id: GO-2026-4883
+    reason: "Indirect via dp-component-test/testcontainers docker client; no patched upstream docker module release available yet"
+  - id: GO-2026-4887
+    reason: "Indirect via dp-component-test/testcontainers docker client; no patched upstream docker module release available yet"

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.1-bookworm
+    tag: 1.26.2-bookworm
 
 inputs:
   - name: dp-permissions-api

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-docker-go
-    tag: 1.26.1-dind-28
+    tag: 1.26.2-dind-28
 
 inputs:
   - name: dp-permissions-api

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go-node
-    tag: 1.26.1-bookworm-golangci-lint-2-node-20
+    tag: 1.26.2-bookworm-golangci-lint-2-node-20
 
 inputs:
   - name: dp-permissions-api

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.1-bookworm
+    tag: 1.26.2-bookworm
 
 inputs:
   - name: dp-permissions-api


### PR DESCRIPTION
### What

- Bump go version to 1.26.2
- Ignore testcontainers warning

### How to review

- Sense check
- Ensure tests pass

### Who can review

!Me
