### PR TITLE
fix(DIS-4879): permissions api fix using local permissions cache, and auth middleware store dependency injected functionality

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-permissions-api

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-docker-go
-    tag: 1.26.3-dind-28
+    tag: 1.26.4-dind-28
 
 inputs:
   - name: dp-permissions-api

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go-node
-    tag: 1.26.3-bookworm-golangci-lint-2-node-20
+    tag: 1.26.4-bookworm-golangci-lint-2-node-20
 
 inputs:
   - name: dp-permissions-api

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-permissions-api

--- a/features/steps/permissions_component.go
+++ b/features/steps/permissions_component.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ONSdigital/dp-authorisation/v2/authorisation"
 	"github.com/ONSdigital/dp-authorisation/v2/authorisationtest"
+	authpermissions "github.com/ONSdigital/dp-authorisation/v2/permissions"
 	componenttest "github.com/ONSdigital/dp-component-test"
 	"github.com/ONSdigital/dp-component-test/utils"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
@@ -247,7 +248,7 @@ func (f *PermissionsComponent) DoGetMongoDB(_ context.Context, _ *config.Config)
 }
 
 // DoGetAuthorisationMiddleware returns an authorisationMock.Middleware object
-func (f *PermissionsComponent) DoGetAuthorisationMiddleware(ctx context.Context, cfg *authorisation.Config) (authorisation.Middleware, error) {
+func (f *PermissionsComponent) DoGetAuthorisationMiddleware(ctx context.Context, cfg *authorisation.Config, _ authpermissions.Store) (authorisation.Middleware, error) {
 	middleware, err := authorisation.NewMiddlewareFromConfig(ctx, cfg, publicSigningkey)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-permissions-api
 go 1.26.3
 
 require (
-	github.com/ONSdigital/dp-authorisation/v2 v2.35.0
+	github.com/ONSdigital/dp-authorisation/v2 v2.36.0
 	github.com/ONSdigital/dp-component-test v1.4.4-alpha
 	github.com/ONSdigital/dp-healthcheck v1.6.4
 	github.com/ONSdigital/dp-mongodb/v3 v3.8.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/dp-permissions-api
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/ONSdigital/dp-authorisation/v2 v2.36.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.270.0 h1:kTSud/+crx9ijAHb5wOCgVx9Lg/tn7gG6pqhJGlOYPA=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.270.0/go.mod h1:bLseTP21r8LCStUEeOdVPyqtrTomOFP/azPjKWW4deA=
-github.com/ONSdigital/dp-authorisation/v2 v2.35.0 h1:1ieZcbJqXtPbU8nXj7NCUlX5c39bGJIf1d3fPKI7kcQ=
-github.com/ONSdigital/dp-authorisation/v2 v2.35.0/go.mod h1:5oYJyRP2t3FA/S5kcEoCNORptQMqDWnTMAkP3cQ5x6Y=
+github.com/ONSdigital/dp-authorisation/v2 v2.36.0 h1:jO0kOfBIMAIcxkuOtGj6kemVs/q9pbiEPVWGewULuxw=
+github.com/ONSdigital/dp-authorisation/v2 v2.36.0/go.mod h1:5oYJyRP2t3FA/S5kcEoCNORptQMqDWnTMAkP3cQ5x6Y=
 github.com/ONSdigital/dp-component-test v1.4.4-alpha h1:efo71nub0AQZO5Bxp8X5As7xytBl60qSHC/FAm08DME=
 github.com/ONSdigital/dp-component-test v1.4.4-alpha/go.mod h1:Wm4JPH5/xyehThk1zbVZ3EKizPl7PefzheFG2e2PYoo=
 github.com/ONSdigital/dp-healthcheck v1.6.4 h1:FhWOuVmob36dYq7AzCdbgyf0Vk58IFitSl8y8pWJ8ck=

--- a/service/authorisation_permissions_store.go
+++ b/service/authorisation_permissions_store.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"context"
+
+	authpermissions "github.com/ONSdigital/dp-authorisation/v2/permissions"
+	"github.com/ONSdigital/dp-permissions-api/models"
+	"github.com/ONSdigital/dp-permissions-api/sdk"
+	"github.com/ONSdigital/log.go/v2/log"
+)
+
+var _ authpermissions.Store = (*authorisationPermissionsStore)(nil)
+
+type permissionsBundler interface {
+	Get(ctx context.Context) (models.Bundle, error)
+}
+
+type authorisationPermissionsStore struct {
+	bundler permissionsBundler
+}
+
+func newAuthorisationPermissionsStore(bundler permissionsBundler) authpermissions.Store {
+	return &authorisationPermissionsStore{
+		bundler: bundler,
+	}
+}
+
+func (s *authorisationPermissionsStore) GetPermissionsBundle(ctx context.Context, _ sdk.Headers) (sdk.Bundle, error) {
+	bundle, err := s.bundler.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	log.Info(ctx, "retrieved permissions bundle from local store")
+
+	return convertAuthorisationPermissionsBundle(bundle), nil
+}
+
+func convertAuthorisationPermissionsBundle(bundle models.Bundle) sdk.Bundle {
+	convertedBundle := make(sdk.Bundle, len(bundle))
+
+	for permission, entityPolicies := range bundle {
+		convertedEntityPolicies := make(sdk.EntityIDToPolicies, len(entityPolicies))
+
+		for entity, policies := range entityPolicies {
+			convertedPolicies := make([]sdk.Policy, 0, len(policies))
+
+			for _, policy := range policies {
+				convertedPolicies = append(convertedPolicies, sdk.Policy{
+					ID: policy.ID,
+					Condition: sdk.Condition{
+						Attribute: policy.Condition.Attribute,
+						Operator:  sdk.Operator(policy.Condition.Operator),
+						Values:    policy.Condition.Values,
+					},
+				})
+			}
+
+			convertedEntityPolicies[entity] = convertedPolicies
+		}
+
+		convertedBundle[permission] = convertedEntityPolicies
+	}
+
+	return convertedBundle
+}

--- a/service/authorisation_permissions_store_test.go
+++ b/service/authorisation_permissions_store_test.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	authpermissions "github.com/ONSdigital/dp-authorisation/v2/permissions"
+	"github.com/ONSdigital/dp-permissions-api/models"
+	"github.com/ONSdigital/dp-permissions-api/sdk"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type permissionsBundlerMock struct {
+	getFunc func(ctx context.Context) (models.Bundle, error)
+}
+
+func (m *permissionsBundlerMock) Get(ctx context.Context) (models.Bundle, error) {
+	return m.getFunc(ctx)
+}
+
+func TestAuthorisationPermissionsStore_GetPermissionsBundle(t *testing.T) {
+	ctx := context.Background()
+
+	Convey("Given a local permissions store with a bundler that returns a bundle", t, func() {
+		bundle := models.Bundle{
+			"legacy.read": map[string][]*models.BundlePolicy{
+				"groups/viewer": {
+					{
+						ID:       "policy-id",
+						Entities: []string{"groups/viewer"},
+						Role:     "viewer",
+						Condition: models.Condition{
+							Attribute: "collection_id",
+							Operator:  models.OperatorStringEquals,
+							Values:    []string{"collection-1"},
+						},
+					},
+				},
+			},
+		}
+		expectedBundle := sdk.Bundle{
+			"legacy.read": map[string][]sdk.Policy{
+				"groups/viewer": {
+					{
+						ID: "policy-id",
+						Condition: sdk.Condition{
+							Attribute: "collection_id",
+							Operator:  sdk.OperatorStringEquals,
+							Values:    []string{"collection-1"},
+						},
+					},
+				},
+			},
+		}
+		bundler := &permissionsBundlerMock{
+			getFunc: func(ctx context.Context) (models.Bundle, error) {
+				return bundle, nil
+			},
+		}
+
+		store := newAuthorisationPermissionsStore(bundler)
+
+		Convey("Then the store implements the authorisation permissions store interface", func() {
+			_, ok := store.(authpermissions.Store)
+			So(ok, ShouldBeTrue)
+		})
+
+		Convey("When GetPermissionsBundle is called", func() {
+			permissionsBundle, err := store.GetPermissionsBundle(ctx, sdk.Headers{})
+
+			Convey("Then no error is returned", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then the converted bundle is returned", func() {
+				So(permissionsBundle, ShouldResemble, expectedBundle)
+			})
+		})
+	})
+
+	Convey("Given a local permissions store with a bundler that returns an error", t, func() {
+		expectedErr := errors.New("bundler error")
+		bundler := &permissionsBundlerMock{
+			getFunc: func(ctx context.Context) (models.Bundle, error) {
+				return nil, expectedErr
+			},
+		}
+		store := newAuthorisationPermissionsStore(bundler)
+
+		Convey("When GetPermissionsBundle is called", func() {
+			permissionsBundle, err := store.GetPermissionsBundle(ctx, sdk.Headers{})
+
+			Convey("Then the expected error is returned", func() {
+				So(err, ShouldEqual, expectedErr)
+			})
+
+			Convey("Then the returned bundle is nil", func() {
+				So(permissionsBundle, ShouldBeNil)
+			})
+		})
+	})
+}

--- a/service/authorisation_permissions_store_test.go
+++ b/service/authorisation_permissions_store_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	authpermissions "github.com/ONSdigital/dp-authorisation/v2/permissions"
 	"github.com/ONSdigital/dp-permissions-api/models"
 	"github.com/ONSdigital/dp-permissions-api/sdk"
 	. "github.com/smartystreets/goconvey/convey"
@@ -60,11 +59,6 @@ func TestAuthorisationPermissionsStore_GetPermissionsBundle(t *testing.T) {
 		}
 
 		store := newAuthorisationPermissionsStore(bundler)
-
-		Convey("Then the store implements the authorisation permissions store interface", func() {
-			_, ok := store.(authpermissions.Store)
-			So(ok, ShouldBeTrue)
-		})
 
 		Convey("When GetPermissionsBundle is called", func() {
 			permissionsBundle, err := store.GetPermissionsBundle(ctx, sdk.Headers{})

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -11,6 +11,7 @@ import (
 	dphttp "github.com/ONSdigital/dp-net/v3/http"
 
 	"github.com/ONSdigital/dp-authorisation/v2/authorisation"
+	authpermissions "github.com/ONSdigital/dp-authorisation/v2/permissions"
 )
 
 // ExternalServiceList holds the initialiser and initialisation state of external services.
@@ -86,12 +87,12 @@ func (e *Init) DoGetMongoDB(ctx context.Context, cfg *config.Config) (Permission
 }
 
 // DoGetAuthorisationMiddleware creates authorisation middleware for the given config
-func (e *Init) DoGetAuthorisationMiddleware(ctx context.Context, authorisationConfig *authorisation.Config) (authorisation.Middleware, error) {
-	return authorisation.NewFeatureFlaggedMiddleware(ctx, authorisationConfig, authorisationConfig.JWTVerificationPublicKeys)
+func (e *Init) DoGetAuthorisationMiddleware(ctx context.Context, authorisationConfig *authorisation.Config, permissionsStore authpermissions.Store) (authorisation.Middleware, error) {
+	return authorisation.NewFeatureFlaggedMiddlewareWithPermissionsStore(ctx, authorisationConfig, authorisationConfig.JWTVerificationPublicKeys, permissionsStore)
 }
 
 // GetAuthorisationMiddleware creates a new instance of authorisation.Middlware
-func (e *ExternalServiceList) GetAuthorisationMiddleware(ctx context.Context, authorisationConfig *authorisation.Config) (authorisation.Middleware, error) {
+func (e *ExternalServiceList) GetAuthorisationMiddleware(ctx context.Context, authorisationConfig *authorisation.Config, permissionsStore authpermissions.Store) (authorisation.Middleware, error) {
 	e.AuthorisationMiddleware = true
-	return e.Init.DoGetAuthorisationMiddleware(ctx, authorisationConfig)
+	return e.Init.DoGetAuthorisationMiddleware(ctx, authorisationConfig, permissionsStore)
 }

--- a/service/initialise_test.go
+++ b/service/initialise_test.go
@@ -6,6 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ONSdigital/dp-authorisation/v2/authorisation"
+	authorisationMock "github.com/ONSdigital/dp-authorisation/v2/authorisation/mock"
+	authpermissions "github.com/ONSdigital/dp-authorisation/v2/permissions"
+	authpermissionsMock "github.com/ONSdigital/dp-authorisation/v2/permissions/mock"
 	"github.com/ONSdigital/dp-permissions-api/config"
 	"github.com/ONSdigital/dp-permissions-api/service"
 	"github.com/ONSdigital/dp-permissions-api/service/mock"
@@ -112,6 +116,59 @@ func TestGetHTTPServer(t *testing.T) {
 				So(newServiceMock.DoGetHTTPServerCalls(), ShouldHaveLength, 1)
 				So(serverMock.ListenAndServeCalls(), ShouldHaveLength, 1)
 				So(err, ShouldBeNil)
+			})
+		})
+	})
+}
+
+func TestGetAuthorisationMiddleware(t *testing.T) {
+	Convey("Given a service list that returns mocked authorisation middleware", t, func() {
+		middlewareMock := &authorisationMock.MiddlewareMock{}
+		permissionsStore := &authpermissionsMock.StoreMock{}
+		newServiceMock := &mock.InitialiserMock{
+			DoGetAuthorisationMiddlewareFunc: func(ctx context.Context, authorisationConfig *authorisation.Config, permissionsStore authpermissions.Store) (authorisation.Middleware, error) {
+				return middlewareMock, nil
+			},
+		}
+		svcList := service.NewServiceList(newServiceMock)
+
+		Convey("When GetAuthorisationMiddleware is called", func() {
+			middleware, err := svcList.GetAuthorisationMiddleware(ctx, cfg.AuthorisationConfig, permissionsStore)
+
+			Convey("Then the AuthorisationMiddleware flag is set to true and the middleware is returned", func() {
+				So(svcList.AuthorisationMiddleware, ShouldBeTrue)
+				So(middleware, ShouldEqual, middlewareMock)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then the authorisation config and permissions store are passed to the initialiser", func() {
+				So(newServiceMock.DoGetAuthorisationMiddlewareCalls(), ShouldHaveLength, 1)
+				So(newServiceMock.DoGetAuthorisationMiddlewareCalls()[0].AuthorisationConfig, ShouldEqual, cfg.AuthorisationConfig)
+				So(newServiceMock.DoGetAuthorisationMiddlewareCalls()[0].PermissionsStore, ShouldEqual, permissionsStore)
+			})
+		})
+	})
+
+	Convey("Given a service list that returns an error for authorisation middleware", t, func() {
+		expectedErr := errors.New("authorisation middleware error")
+		permissionsStore := &authpermissionsMock.StoreMock{}
+		newServiceMock := &mock.InitialiserMock{
+			DoGetAuthorisationMiddlewareFunc: func(ctx context.Context, authorisationConfig *authorisation.Config, permissionsStore authpermissions.Store) (authorisation.Middleware, error) {
+				return nil, expectedErr
+			},
+		}
+		svcList := service.NewServiceList(newServiceMock)
+
+		Convey("When GetAuthorisationMiddleware is called", func() {
+			middleware, err := svcList.GetAuthorisationMiddleware(ctx, cfg.AuthorisationConfig, permissionsStore)
+
+			Convey("Then the error is returned", func() {
+				So(middleware, ShouldBeNil)
+				So(err, ShouldEqual, expectedErr)
+			})
+
+			Convey("Then the AuthorisationMiddleware flag is still set to true", func() {
+				So(svcList.AuthorisationMiddleware, ShouldBeTrue)
 			})
 		})
 	})

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ONSdigital/dp-permissions-api/config"
 
 	"github.com/ONSdigital/dp-authorisation/v2/authorisation"
+	authpermissions "github.com/ONSdigital/dp-authorisation/v2/permissions"
 )
 
 //go:generate moq -out mock/initialiser.go -pkg mock . Initialiser
@@ -23,7 +24,7 @@ type Initialiser interface {
 	DoGetHTTPServer(bindAddr string, router http.Handler) HTTPServer
 	DoGetHealthCheck(cfg *config.Config, buildTime, gitCommit, version string) (HealthChecker, error)
 	DoGetMongoDB(ctx context.Context, cfg *config.Config) (PermissionsStore, error)
-	DoGetAuthorisationMiddleware(ctx context.Context, authorisationConfig *authorisation.Config) (authorisation.Middleware, error)
+	DoGetAuthorisationMiddleware(ctx context.Context, authorisationConfig *authorisation.Config, permissionsStore authpermissions.Store) (authorisation.Middleware, error)
 }
 
 // HTTPServer defines the required methods from the HTTP server

--- a/service/mock/healthCheck.go
+++ b/service/mock/healthCheck.go
@@ -17,28 +17,28 @@ var _ service.HealthChecker = &HealthCheckerMock{}
 
 // HealthCheckerMock is a mock implementation of service.HealthChecker.
 //
-// 	func TestSomethingThatUsesHealthChecker(t *testing.T) {
+//	func TestSomethingThatUsesHealthChecker(t *testing.T) {
 //
-// 		// make and configure a mocked service.HealthChecker
-// 		mockedHealthChecker := &HealthCheckerMock{
-// 			AddCheckFunc: func(name string, checker healthcheck.Checker) error {
-// 				panic("mock out the AddCheck method")
-// 			},
-// 			HandlerFunc: func(w http.ResponseWriter, req *http.Request)  {
-// 				panic("mock out the Handler method")
-// 			},
-// 			StartFunc: func(ctx context.Context)  {
-// 				panic("mock out the Start method")
-// 			},
-// 			StopFunc: func()  {
-// 				panic("mock out the Stop method")
-// 			},
-// 		}
+//		// make and configure a mocked service.HealthChecker
+//		mockedHealthChecker := &HealthCheckerMock{
+//			AddCheckFunc: func(name string, checker healthcheck.Checker) error {
+//				panic("mock out the AddCheck method")
+//			},
+//			HandlerFunc: func(w http.ResponseWriter, req *http.Request)  {
+//				panic("mock out the Handler method")
+//			},
+//			StartFunc: func(ctx context.Context)  {
+//				panic("mock out the Start method")
+//			},
+//			StopFunc: func()  {
+//				panic("mock out the Stop method")
+//			},
+//		}
 //
-// 		// use mockedHealthChecker in code that requires service.HealthChecker
-// 		// and then make assertions.
+//		// use mockedHealthChecker in code that requires service.HealthChecker
+//		// and then make assertions.
 //
-// 	}
+//	}
 type HealthCheckerMock struct {
 	// AddCheckFunc mocks the AddCheck method.
 	AddCheckFunc func(name string, checker healthcheck.Checker) error
@@ -103,7 +103,8 @@ func (mock *HealthCheckerMock) AddCheck(name string, checker healthcheck.Checker
 
 // AddCheckCalls gets all the calls that were made to AddCheck.
 // Check the length with:
-//     len(mockedHealthChecker.AddCheckCalls())
+//
+//	len(mockedHealthChecker.AddCheckCalls())
 func (mock *HealthCheckerMock) AddCheckCalls() []struct {
 	Name    string
 	Checker healthcheck.Checker
@@ -138,7 +139,8 @@ func (mock *HealthCheckerMock) Handler(w http.ResponseWriter, req *http.Request)
 
 // HandlerCalls gets all the calls that were made to Handler.
 // Check the length with:
-//     len(mockedHealthChecker.HandlerCalls())
+//
+//	len(mockedHealthChecker.HandlerCalls())
 func (mock *HealthCheckerMock) HandlerCalls() []struct {
 	W   http.ResponseWriter
 	Req *http.Request
@@ -171,7 +173,8 @@ func (mock *HealthCheckerMock) Start(ctx context.Context) {
 
 // StartCalls gets all the calls that were made to Start.
 // Check the length with:
-//     len(mockedHealthChecker.StartCalls())
+//
+//	len(mockedHealthChecker.StartCalls())
 func (mock *HealthCheckerMock) StartCalls() []struct {
 	Ctx context.Context
 } {
@@ -199,7 +202,8 @@ func (mock *HealthCheckerMock) Stop() {
 
 // StopCalls gets all the calls that were made to Stop.
 // Check the length with:
-//     len(mockedHealthChecker.StopCalls())
+//
+//	len(mockedHealthChecker.StopCalls())
 func (mock *HealthCheckerMock) StopCalls() []struct {
 } {
 	var calls []struct {

--- a/service/mock/initialiser.go
+++ b/service/mock/initialiser.go
@@ -6,6 +6,7 @@ package mock
 import (
 	"context"
 	"github.com/ONSdigital/dp-authorisation/v2/authorisation"
+	authpermissions "github.com/ONSdigital/dp-authorisation/v2/permissions"
 	"github.com/ONSdigital/dp-permissions-api/config"
 	"github.com/ONSdigital/dp-permissions-api/service"
 	"net/http"
@@ -18,31 +19,31 @@ var _ service.Initialiser = &InitialiserMock{}
 
 // InitialiserMock is a mock implementation of service.Initialiser.
 //
-// 	func TestSomethingThatUsesInitialiser(t *testing.T) {
+//	func TestSomethingThatUsesInitialiser(t *testing.T) {
 //
-// 		// make and configure a mocked service.Initialiser
-// 		mockedInitialiser := &InitialiserMock{
-// 			DoGetAuthorisationMiddlewareFunc: func(ctx context.Context, authorisationConfig *authorisation.Config) (authorisation.Middleware, error) {
-// 				panic("mock out the DoGetAuthorisationMiddleware method")
-// 			},
-// 			DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.HTTPServer {
-// 				panic("mock out the DoGetHTTPServer method")
-// 			},
-// 			DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
-// 				panic("mock out the DoGetHealthCheck method")
-// 			},
-// 			DoGetMongoDBFunc: func(ctx context.Context, cfg *config.Config) (service.PermissionsStore, error) {
-// 				panic("mock out the DoGetMongoDB method")
-// 			},
-// 		}
+//		// make and configure a mocked service.Initialiser
+//		mockedInitialiser := &InitialiserMock{
+//			DoGetAuthorisationMiddlewareFunc: func(ctx context.Context, authorisationConfig *authorisation.Config, permissionsStore authpermissions.Store) (authorisation.Middleware, error) {
+//				panic("mock out the DoGetAuthorisationMiddleware method")
+//			},
+//			DoGetHTTPServerFunc: func(bindAddr string, router http.Handler) service.HTTPServer {
+//				panic("mock out the DoGetHTTPServer method")
+//			},
+//			DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
+//				panic("mock out the DoGetHealthCheck method")
+//			},
+//			DoGetMongoDBFunc: func(ctx context.Context, cfg *config.Config) (service.PermissionsStore, error) {
+//				panic("mock out the DoGetMongoDB method")
+//			},
+//		}
 //
-// 		// use mockedInitialiser in code that requires service.Initialiser
-// 		// and then make assertions.
+//		// use mockedInitialiser in code that requires service.Initialiser
+//		// and then make assertions.
 //
-// 	}
+//	}
 type InitialiserMock struct {
 	// DoGetAuthorisationMiddlewareFunc mocks the DoGetAuthorisationMiddleware method.
-	DoGetAuthorisationMiddlewareFunc func(ctx context.Context, authorisationConfig *authorisation.Config) (authorisation.Middleware, error)
+	DoGetAuthorisationMiddlewareFunc func(ctx context.Context, authorisationConfig *authorisation.Config, permissionsStore authpermissions.Store) (authorisation.Middleware, error)
 
 	// DoGetHTTPServerFunc mocks the DoGetHTTPServer method.
 	DoGetHTTPServerFunc func(bindAddr string, router http.Handler) service.HTTPServer
@@ -61,6 +62,8 @@ type InitialiserMock struct {
 			Ctx context.Context
 			// AuthorisationConfig is the authorisationConfig argument value.
 			AuthorisationConfig *authorisation.Config
+			// PermissionsStore is the permissionsStore argument value.
+			PermissionsStore authpermissions.Store
 		}
 		// DoGetHTTPServer holds details about calls to the DoGetHTTPServer method.
 		DoGetHTTPServer []struct {
@@ -95,33 +98,38 @@ type InitialiserMock struct {
 }
 
 // DoGetAuthorisationMiddleware calls DoGetAuthorisationMiddlewareFunc.
-func (mock *InitialiserMock) DoGetAuthorisationMiddleware(ctx context.Context, authorisationConfig *authorisation.Config) (authorisation.Middleware, error) {
+func (mock *InitialiserMock) DoGetAuthorisationMiddleware(ctx context.Context, authorisationConfig *authorisation.Config, permissionsStore authpermissions.Store) (authorisation.Middleware, error) {
 	if mock.DoGetAuthorisationMiddlewareFunc == nil {
 		panic("InitialiserMock.DoGetAuthorisationMiddlewareFunc: method is nil but Initialiser.DoGetAuthorisationMiddleware was just called")
 	}
 	callInfo := struct {
 		Ctx                 context.Context
 		AuthorisationConfig *authorisation.Config
+		PermissionsStore    authpermissions.Store
 	}{
 		Ctx:                 ctx,
 		AuthorisationConfig: authorisationConfig,
+		PermissionsStore:    permissionsStore,
 	}
 	mock.lockDoGetAuthorisationMiddleware.Lock()
 	mock.calls.DoGetAuthorisationMiddleware = append(mock.calls.DoGetAuthorisationMiddleware, callInfo)
 	mock.lockDoGetAuthorisationMiddleware.Unlock()
-	return mock.DoGetAuthorisationMiddlewareFunc(ctx, authorisationConfig)
+	return mock.DoGetAuthorisationMiddlewareFunc(ctx, authorisationConfig, permissionsStore)
 }
 
 // DoGetAuthorisationMiddlewareCalls gets all the calls that were made to DoGetAuthorisationMiddleware.
 // Check the length with:
-//     len(mockedInitialiser.DoGetAuthorisationMiddlewareCalls())
+//
+//	len(mockedInitialiser.DoGetAuthorisationMiddlewareCalls())
 func (mock *InitialiserMock) DoGetAuthorisationMiddlewareCalls() []struct {
 	Ctx                 context.Context
 	AuthorisationConfig *authorisation.Config
+	PermissionsStore    authpermissions.Store
 } {
 	var calls []struct {
 		Ctx                 context.Context
 		AuthorisationConfig *authorisation.Config
+		PermissionsStore    authpermissions.Store
 	}
 	mock.lockDoGetAuthorisationMiddleware.RLock()
 	calls = mock.calls.DoGetAuthorisationMiddleware
@@ -149,7 +157,8 @@ func (mock *InitialiserMock) DoGetHTTPServer(bindAddr string, router http.Handle
 
 // DoGetHTTPServerCalls gets all the calls that were made to DoGetHTTPServer.
 // Check the length with:
-//     len(mockedInitialiser.DoGetHTTPServerCalls())
+//
+//	len(mockedInitialiser.DoGetHTTPServerCalls())
 func (mock *InitialiserMock) DoGetHTTPServerCalls() []struct {
 	BindAddr string
 	Router   http.Handler
@@ -188,7 +197,8 @@ func (mock *InitialiserMock) DoGetHealthCheck(cfg *config.Config, buildTime stri
 
 // DoGetHealthCheckCalls gets all the calls that were made to DoGetHealthCheck.
 // Check the length with:
-//     len(mockedInitialiser.DoGetHealthCheckCalls())
+//
+//	len(mockedInitialiser.DoGetHealthCheckCalls())
 func (mock *InitialiserMock) DoGetHealthCheckCalls() []struct {
 	Cfg       *config.Config
 	BuildTime string
@@ -227,7 +237,8 @@ func (mock *InitialiserMock) DoGetMongoDB(ctx context.Context, cfg *config.Confi
 
 // DoGetMongoDBCalls gets all the calls that were made to DoGetMongoDB.
 // Check the length with:
-//     len(mockedInitialiser.DoGetMongoDBCalls())
+//
+//	len(mockedInitialiser.DoGetMongoDBCalls())
 func (mock *InitialiserMock) DoGetMongoDBCalls() []struct {
 	Ctx context.Context
 	Cfg *config.Config

--- a/service/mock/server.go
+++ b/service/mock/server.go
@@ -15,22 +15,22 @@ var _ service.HTTPServer = &HTTPServerMock{}
 
 // HTTPServerMock is a mock implementation of service.HTTPServer.
 //
-// 	func TestSomethingThatUsesHTTPServer(t *testing.T) {
+//	func TestSomethingThatUsesHTTPServer(t *testing.T) {
 //
-// 		// make and configure a mocked service.HTTPServer
-// 		mockedHTTPServer := &HTTPServerMock{
-// 			ListenAndServeFunc: func() error {
-// 				panic("mock out the ListenAndServe method")
-// 			},
-// 			ShutdownFunc: func(ctx context.Context) error {
-// 				panic("mock out the Shutdown method")
-// 			},
-// 		}
+//		// make and configure a mocked service.HTTPServer
+//		mockedHTTPServer := &HTTPServerMock{
+//			ListenAndServeFunc: func() error {
+//				panic("mock out the ListenAndServe method")
+//			},
+//			ShutdownFunc: func(ctx context.Context) error {
+//				panic("mock out the Shutdown method")
+//			},
+//		}
 //
-// 		// use mockedHTTPServer in code that requires service.HTTPServer
-// 		// and then make assertions.
+//		// use mockedHTTPServer in code that requires service.HTTPServer
+//		// and then make assertions.
 //
-// 	}
+//	}
 type HTTPServerMock struct {
 	// ListenAndServeFunc mocks the ListenAndServe method.
 	ListenAndServeFunc func() error
@@ -68,7 +68,8 @@ func (mock *HTTPServerMock) ListenAndServe() error {
 
 // ListenAndServeCalls gets all the calls that were made to ListenAndServe.
 // Check the length with:
-//     len(mockedHTTPServer.ListenAndServeCalls())
+//
+//	len(mockedHTTPServer.ListenAndServeCalls())
 func (mock *HTTPServerMock) ListenAndServeCalls() []struct {
 } {
 	var calls []struct {
@@ -97,7 +98,8 @@ func (mock *HTTPServerMock) Shutdown(ctx context.Context) error {
 
 // ShutdownCalls gets all the calls that were made to Shutdown.
 // Check the length with:
-//     len(mockedHTTPServer.ShutdownCalls())
+//
+//	len(mockedHTTPServer.ShutdownCalls())
 func (mock *HTTPServerMock) ShutdownCalls() []struct {
 	Ctx context.Context
 } {

--- a/service/mock/store.go
+++ b/service/mock/store.go
@@ -17,46 +17,46 @@ var _ service.PermissionsStore = &PermissionsStoreMock{}
 
 // PermissionsStoreMock is a mock implementation of service.PermissionsStore.
 //
-// 	func TestSomethingThatUsesPermissionsStore(t *testing.T) {
+//	func TestSomethingThatUsesPermissionsStore(t *testing.T) {
 //
-// 		// make and configure a mocked service.PermissionsStore
-// 		mockedPermissionsStore := &PermissionsStoreMock{
-// 			AddPolicyFunc: func(ctx context.Context, policy *models.Policy) (*models.Policy, error) {
-// 				panic("mock out the AddPolicy method")
-// 			},
-// 			CheckerFunc: func(ctx context.Context, state *healthcheck.CheckState) error {
-// 				panic("mock out the Checker method")
-// 			},
-// 			CloseFunc: func(ctx context.Context) error {
-// 				panic("mock out the Close method")
-// 			},
-// 			DeletePolicyFunc: func(ctx context.Context, id string) error {
-// 				panic("mock out the DeletePolicy method")
-// 			},
-// 			GetAllBundlePoliciesFunc: func(ctx context.Context) ([]*models.BundlePolicy, error) {
-// 				panic("mock out the GetAllBundlePolicies method")
-// 			},
-// 			GetAllRolesFunc: func(ctx context.Context) ([]*models.Role, error) {
-// 				panic("mock out the GetAllRoles method")
-// 			},
-// 			GetPolicyFunc: func(ctx context.Context, id string) (*models.Policy, error) {
-// 				panic("mock out the GetPolicy method")
-// 			},
-// 			GetRoleFunc: func(ctx context.Context, id string) (*models.Role, error) {
-// 				panic("mock out the GetRole method")
-// 			},
-// 			GetRolesFunc: func(ctx context.Context, offset int, limit int) (*models.Roles, error) {
-// 				panic("mock out the GetRoles method")
-// 			},
-// 			UpdatePolicyFunc: func(ctx context.Context, policy *models.Policy) (*models.UpdateResult, error) {
-// 				panic("mock out the UpdatePolicy method")
-// 			},
-// 		}
+//		// make and configure a mocked service.PermissionsStore
+//		mockedPermissionsStore := &PermissionsStoreMock{
+//			AddPolicyFunc: func(ctx context.Context, policy *models.Policy) (*models.Policy, error) {
+//				panic("mock out the AddPolicy method")
+//			},
+//			CheckerFunc: func(ctx context.Context, state *healthcheck.CheckState) error {
+//				panic("mock out the Checker method")
+//			},
+//			CloseFunc: func(ctx context.Context) error {
+//				panic("mock out the Close method")
+//			},
+//			DeletePolicyFunc: func(ctx context.Context, id string) error {
+//				panic("mock out the DeletePolicy method")
+//			},
+//			GetAllBundlePoliciesFunc: func(ctx context.Context) ([]*models.BundlePolicy, error) {
+//				panic("mock out the GetAllBundlePolicies method")
+//			},
+//			GetAllRolesFunc: func(ctx context.Context) ([]*models.Role, error) {
+//				panic("mock out the GetAllRoles method")
+//			},
+//			GetPolicyFunc: func(ctx context.Context, id string) (*models.Policy, error) {
+//				panic("mock out the GetPolicy method")
+//			},
+//			GetRoleFunc: func(ctx context.Context, id string) (*models.Role, error) {
+//				panic("mock out the GetRole method")
+//			},
+//			GetRolesFunc: func(ctx context.Context, offset int, limit int) (*models.Roles, error) {
+//				panic("mock out the GetRoles method")
+//			},
+//			UpdatePolicyFunc: func(ctx context.Context, policy *models.Policy) (*models.UpdateResult, error) {
+//				panic("mock out the UpdatePolicy method")
+//			},
+//		}
 //
-// 		// use mockedPermissionsStore in code that requires service.PermissionsStore
-// 		// and then make assertions.
+//		// use mockedPermissionsStore in code that requires service.PermissionsStore
+//		// and then make assertions.
 //
-// 	}
+//	}
 type PermissionsStoreMock struct {
 	// AddPolicyFunc mocks the AddPolicy method.
 	AddPolicyFunc func(ctx context.Context, policy *models.Policy) (*models.Policy, error)
@@ -189,7 +189,8 @@ func (mock *PermissionsStoreMock) AddPolicy(ctx context.Context, policy *models.
 
 // AddPolicyCalls gets all the calls that were made to AddPolicy.
 // Check the length with:
-//     len(mockedPermissionsStore.AddPolicyCalls())
+//
+//	len(mockedPermissionsStore.AddPolicyCalls())
 func (mock *PermissionsStoreMock) AddPolicyCalls() []struct {
 	Ctx    context.Context
 	Policy *models.Policy
@@ -224,7 +225,8 @@ func (mock *PermissionsStoreMock) Checker(ctx context.Context, state *healthchec
 
 // CheckerCalls gets all the calls that were made to Checker.
 // Check the length with:
-//     len(mockedPermissionsStore.CheckerCalls())
+//
+//	len(mockedPermissionsStore.CheckerCalls())
 func (mock *PermissionsStoreMock) CheckerCalls() []struct {
 	Ctx   context.Context
 	State *healthcheck.CheckState
@@ -257,7 +259,8 @@ func (mock *PermissionsStoreMock) Close(ctx context.Context) error {
 
 // CloseCalls gets all the calls that were made to Close.
 // Check the length with:
-//     len(mockedPermissionsStore.CloseCalls())
+//
+//	len(mockedPermissionsStore.CloseCalls())
 func (mock *PermissionsStoreMock) CloseCalls() []struct {
 	Ctx context.Context
 } {
@@ -290,7 +293,8 @@ func (mock *PermissionsStoreMock) DeletePolicy(ctx context.Context, id string) e
 
 // DeletePolicyCalls gets all the calls that were made to DeletePolicy.
 // Check the length with:
-//     len(mockedPermissionsStore.DeletePolicyCalls())
+//
+//	len(mockedPermissionsStore.DeletePolicyCalls())
 func (mock *PermissionsStoreMock) DeletePolicyCalls() []struct {
 	Ctx context.Context
 	ID  string
@@ -323,7 +327,8 @@ func (mock *PermissionsStoreMock) GetAllBundlePolicies(ctx context.Context) ([]*
 
 // GetAllBundlePoliciesCalls gets all the calls that were made to GetAllBundlePolicies.
 // Check the length with:
-//     len(mockedPermissionsStore.GetAllBundlePoliciesCalls())
+//
+//	len(mockedPermissionsStore.GetAllBundlePoliciesCalls())
 func (mock *PermissionsStoreMock) GetAllBundlePoliciesCalls() []struct {
 	Ctx context.Context
 } {
@@ -354,7 +359,8 @@ func (mock *PermissionsStoreMock) GetAllRoles(ctx context.Context) ([]*models.Ro
 
 // GetAllRolesCalls gets all the calls that were made to GetAllRoles.
 // Check the length with:
-//     len(mockedPermissionsStore.GetAllRolesCalls())
+//
+//	len(mockedPermissionsStore.GetAllRolesCalls())
 func (mock *PermissionsStoreMock) GetAllRolesCalls() []struct {
 	Ctx context.Context
 } {
@@ -387,7 +393,8 @@ func (mock *PermissionsStoreMock) GetPolicy(ctx context.Context, id string) (*mo
 
 // GetPolicyCalls gets all the calls that were made to GetPolicy.
 // Check the length with:
-//     len(mockedPermissionsStore.GetPolicyCalls())
+//
+//	len(mockedPermissionsStore.GetPolicyCalls())
 func (mock *PermissionsStoreMock) GetPolicyCalls() []struct {
 	Ctx context.Context
 	ID  string
@@ -422,7 +429,8 @@ func (mock *PermissionsStoreMock) GetRole(ctx context.Context, id string) (*mode
 
 // GetRoleCalls gets all the calls that were made to GetRole.
 // Check the length with:
-//     len(mockedPermissionsStore.GetRoleCalls())
+//
+//	len(mockedPermissionsStore.GetRoleCalls())
 func (mock *PermissionsStoreMock) GetRoleCalls() []struct {
 	Ctx context.Context
 	ID  string
@@ -459,7 +467,8 @@ func (mock *PermissionsStoreMock) GetRoles(ctx context.Context, offset int, limi
 
 // GetRolesCalls gets all the calls that were made to GetRoles.
 // Check the length with:
-//     len(mockedPermissionsStore.GetRolesCalls())
+//
+//	len(mockedPermissionsStore.GetRolesCalls())
 func (mock *PermissionsStoreMock) GetRolesCalls() []struct {
 	Ctx    context.Context
 	Offset int
@@ -496,7 +505,8 @@ func (mock *PermissionsStoreMock) UpdatePolicy(ctx context.Context, policy *mode
 
 // UpdatePolicyCalls gets all the calls that were made to UpdatePolicy.
 // Check the length with:
-//     len(mockedPermissionsStore.UpdatePolicyCalls())
+//
+//	len(mockedPermissionsStore.UpdatePolicyCalls())
 func (mock *PermissionsStoreMock) UpdatePolicyCalls() []struct {
 	Ctx    context.Context
 	Policy *models.Policy

--- a/service/service.go
+++ b/service/service.go
@@ -44,8 +44,9 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	}
 
 	bundler := permissions.NewBundler(mongoDB)
+	authorisationPermissionsStore := newAuthorisationPermissionsStore(bundler)
 
-	authorisationMiddleware, err := serviceList.GetAuthorisationMiddleware(ctx, cfg.AuthorisationConfig)
+	authorisationMiddleware, err := serviceList.GetAuthorisationMiddleware(ctx, cfg.AuthorisationConfig, authorisationPermissionsStore)
 	if err != nil {
 		log.Fatal(ctx, "could not instantiate authorisation middleware", err)
 		return nil, err

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ONSdigital/dp-authorisation/v2/authorisation"
+	authpermissions "github.com/ONSdigital/dp-authorisation/v2/permissions"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 
 	"github.com/ONSdigital/dp-permissions-api/config"
@@ -89,7 +90,7 @@ func TestRun(t *testing.T) {
 			}, nil
 		}
 
-		funcDoGetAuthorisationMiddleware := func(ctx context.Context, authorisationConfig *authorisation.Config) (authorisation.Middleware, error) {
+		funcDoGetAuthorisationMiddleware := func(ctx context.Context, authorisationConfig *authorisation.Config, permissionsStore authpermissions.Store) (authorisation.Middleware, error) {
 			return &authorisationMock.MiddlewareMock{
 				RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
 					return handlerFunc
@@ -164,6 +165,7 @@ func TestRun(t *testing.T) {
 				So(initMock.DoGetHTTPServerCalls()[0].BindAddr, ShouldEqual, "localhost:25400")
 				So(len(hcMock.StartCalls()), ShouldEqual, 1)
 				So(initMock.DoGetAuthorisationMiddlewareCalls(), ShouldHaveLength, 1)
+				So(initMock.DoGetAuthorisationMiddlewareCalls()[0].PermissionsStore, ShouldNotBeNil)
 				//!!! a call needed to stop the server, maybe ?
 				serverWg.Wait() // Wait for HTTP server go-routine to finish
 				So(len(serverMock.ListenAndServeCalls()), ShouldEqual, 1)
@@ -239,7 +241,7 @@ func TestRun(t *testing.T) {
 				DoGetHealthCheckFunc: funcDoGetHealthcheckOk,
 				DoGetHTTPServerFunc:  funcDoGetFailingHTTPServer,
 				DoGetMongoDBFunc:     funcDoGetMongoDBOk,
-				DoGetAuthorisationMiddlewareFunc: func(ctx context.Context, authorisationConfig *authorisation.Config) (authorisation.Middleware, error) {
+				DoGetAuthorisationMiddlewareFunc: func(ctx context.Context, authorisationConfig *authorisation.Config, permissionsStore authpermissions.Store) (authorisation.Middleware, error) {
 					return nil, expectedError
 				},
 			}
@@ -281,7 +283,7 @@ func TestClose(t *testing.T) {
 			},
 		}
 
-		funcDoGetAuthorisationMiddleware := func(ctx context.Context, authorisationConfig *authorisation.Config) (authorisation.Middleware, error) {
+		funcDoGetAuthorisationMiddleware := func(ctx context.Context, authorisationConfig *authorisation.Config, permissionsStore authpermissions.Store) (authorisation.Middleware, error) {
 			return &authorisationMock.MiddlewareMock{
 				RequireFunc: func(permission string, handlerFunc http.HandlerFunc) http.HandlerFunc {
 					return handlerFunc


### PR DESCRIPTION
### What

- using auth middleware v2.36.0 to inject the local permissions store from permissions bundle
- decoupled using the services own permissions bundle endpoint
- added an adapter pattern using go idioms for the local permissions store functionality
- added logging to show permissions store retrieval 
- updated test mocks and service tests

### How to review

stand up permission api locally with compose stack and authentication stub and ensure the permissions api no longer does a loopback call to it's service for getting permissions bundle.
Ensure no failure on initial startup

### Who can review

!me
